### PR TITLE
Support sprockets-rails 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script: "bundle exec rake test"
 gemfile:
   - gemfiles/sprockets_2_12.gemfile
   - gemfiles/sprockets_3_0.gemfile
+  - gemfiles/sprockets-rails_3_0.gemfile
   - gemfiles/rails_4_2.gemfile
   - gemfiles/rails_4_1.gemfile
   - gemfiles/rails_4_0.gemfile

--- a/gemfiles/sprockets-rails_3_0.gemfile
+++ b/gemfiles/sprockets-rails_3_0.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem "sprockets", "~> 3.0.0"
+gem "sprockets-rails", github: "rails/sprockets-rails"
+
+# Specify your gem's dependencies in sassc-rails.gemspec
+gemspec path: "../"

--- a/lib/sassc/rails/railtie.rb
+++ b/lib/sassc/rails/railtie.rb
@@ -44,14 +44,14 @@ module SassC::Rails
       #   config.sass.full_exception = app.config.consider_all_requests_local
       # end
 
-      if app.assets
-        app.assets.context_class.class_eval do
+      app.config.assets.configure do |env|
+        env.context_class.class_eval do
           class_attribute :sass_config
           self.sass_config = app.config.sass
         end
 
-        app.assets.register_engine '.sass', SassC::Rails::SassTemplate
-        app.assets.register_engine '.scss', SassC::Rails::ScssTemplate
+        env.register_engine '.sass', SassC::Rails::SassTemplate
+        env.register_engine '.scss', SassC::Rails::ScssTemplate
       end
     end
 

--- a/test/sassc_rails_test.rb
+++ b/test/sassc_rails_test.rb
@@ -22,7 +22,9 @@ class SassRailsTest < MiniTest::Unit::TestCase
     @app.config.sass.line_comments    = false
 
     # Add a fake compressor for testing purposes
-    @app.assets.register_compressor "text/css", :test, TestCompressor
+    @app.config.assets.configure do |env|
+      env.register_compressor "text/css", :test, TestCompressor
+    end
 
     Rails.backtrace_cleaner.remove_silencers!
   end

--- a/test/sassc_rails_test.rb
+++ b/test/sassc_rails_test.rb
@@ -232,11 +232,12 @@ class SassRailsTest < MiniTest::Unit::TestCase
   end
 
   def test_sassc_compression_is_used
-    initialize_prod!
-
     engine = stub(render: "")
     SassC::Engine.expects(:new).returns(engine)
     SassC::Engine.expects(:new).with("", {style: :compressed}).returns(engine)
+
+    initialize_prod!
+
     render_asset("application.scss")
   end
 

--- a/test/sassc_rails_test.rb
+++ b/test/sassc_rails_test.rb
@@ -324,5 +324,7 @@ class SassRailsTest < MiniTest::Unit::TestCase
     end
   end
 
-  class TestCompressor; end
+  class TestCompressor
+    def self.call(*); end
+  end
 end


### PR DESCRIPTION
sprockets-rails 3 will support both Sprockets 3 and Sprockets 4 and also introduce new features only present on Sprockets 3.

I changed this gem to work with sprockets-rails 3.