### PR TITLE
Remove dependency on full Rails

### DIFF
--- a/sassc-rails.gemspec
+++ b/sassc-rails.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "tilt"
 
-  spec.add_dependency 'rails', '>= 4.0.0'
+  spec.add_dependency 'railties', '>= 4.0.0'
   spec.add_dependency 'sprockets', '> 2.11'
+  spec.add_dependency 'sprockets-rails'
 end


### PR DESCRIPTION
`railties` has most of Rails dependencies and will not depend on `activerecord` for example. Since we use Sequel rather than ActiveRecord, requiring sassc was the culprit for adding activerecord to the bundle for no good reason.