### PR TITLE
Use Sprockets::SassProcessor if available

### DIFF
--- a/lib/sassc/rails/template.rb
+++ b/lib/sassc/rails/template.rb
@@ -1,9 +1,13 @@
 require "sprockets/version"
-require "sprockets/sass_template"
+begin
+  require "sprockets/sass_processor"
+rescue LoadError
+  require "sprockets/sass_template"
+end
 require "sprockets/utils"
 
 module SassC::Rails
-  class SassTemplate < Sprockets::SassTemplate
+  class SassTemplate < (defined?(Sprockets::SassProcessor) ? Sprockets::SassProcessor : Sprockets::SassTemplate)
     module Sprockets3
       def call(input)
         context = input[:environment].context_class.new(input)


### PR DESCRIPTION
`Sprockets::SassTemplate` is deprecated https://github.com/rails/sprockets/commit/2c9333bd1b6a55f791a3f2ca1389bf152cea18ba and will be removed in 4.x.