### PR TITLE
Updated sassc to 1.6.0 -> 1.9.x

### DIFF
--- a/sassc-rails.gemspec
+++ b/sassc-rails.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   # Unfortunately we require sass for now, so that we can
   # reuse portions of the Sprockets template
   spec.add_dependency 'sass'
-  spec.add_dependency "sassc", "~> 1.6"
+  spec.add_dependency "sassc", "~> 1.8.4"
 
   spec.add_dependency "tilt"
 

--- a/sassc-rails.gemspec
+++ b/sassc-rails.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   # Unfortunately we require sass for now, so that we can
   # reuse portions of the Sprockets template
   spec.add_dependency 'sass'
-  spec.add_dependency "sassc", "~> 1.8.4"
+  spec.add_dependency "sassc", "~> 1.9.0"
 
   spec.add_dependency "tilt"
 

--- a/sassc-rails.gemspec
+++ b/sassc-rails.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   # Unfortunately we require sass for now, so that we can
   # reuse portions of the Sprockets template
   spec.add_dependency 'sass'
-  spec.add_dependency "sassc", "~> 1.9.0"
+  spec.add_dependency "sassc", "~> 1.9"
 
   spec.add_dependency "tilt"
 


### PR DESCRIPTION
This upgrades the dependency of the sassc-gem that uses libsass 3.3 instead of what i think should be 3.2.x