### PR TITLE
support config.sass.load_paths

### DIFF
--- a/test/dummy/app/assets/stylesheets/imports_test.scss
+++ b/test/dummy/app/assets/stylesheets/imports_test.scss
@@ -13,6 +13,7 @@
 @import "css_sass_handler";
 @import "css_scss_erb_handler";
 @import "css_sass_erb_handler";
+@import 'partial_in_load_paths';
 
 .main {
   color: yellow;

--- a/test/dummy/app/assets/stylesheets/in_load_paths/partial_in_load_paths.scss
+++ b/test/dummy/app/assets/stylesheets/in_load_paths/partial_in_load_paths.scss
@@ -1,0 +1,3 @@
+.partial_in_load_paths {
+  color: #BADA55
+}

--- a/test/sassc_rails_test.rb
+++ b/test/sassc_rails_test.rb
@@ -116,6 +116,7 @@ class SassRailsTest < MiniTest::Unit::TestCase
   end
 
   def test_sass_imports_work_correctly
+    app.config.sass.load_paths << Rails.root.join('app/assets/stylesheets/in_load_paths')
     initialize!
 
     css_output = render_asset("imports_test.css")
@@ -145,6 +146,8 @@ class SassRailsTest < MiniTest::Unit::TestCase
 
     assert_match /globbed/,                  css_output
     assert_match /nested-glob/,              css_output
+
+    assert_match /partial_in_load_paths/,    css_output
   end
 
   def test_style_config_item_is_defaulted_to_expanded_in_development_mode


### PR DESCRIPTION
I have some concerns about the usage of construction `&method(:safe_merge)`. It looks nice, but I've heard that it's slower than calling a block. Do you have some performance tests?