### PR TITLE
Silene Sprockets deprecation message

### DIFF
--- a/lib/sassc/rails/railtie.rb
+++ b/lib/sassc/rails/railtie.rb
@@ -56,8 +56,13 @@ module SassC::Rails
         end
 
         if env.respond_to?(:register_engine)
-          env.register_engine '.sass', SassC::Rails::SassTemplate
-          env.register_engine '.scss', SassC::Rails::ScssTemplate
+          [
+            ['.sass', SassC::Rails::SassTemplate],
+            ['.scss', SassC::Rails::ScssTemplate]
+          ].each do |engine|
+            engine << { silence_deprecation: true } if Sprockets::VERSION.start_with?("3")
+            env.register_engine(*engine)
+          end
         end
       end
     end


### PR DESCRIPTION
## Overview

There is a [PR](https://github.com/sass/sassc-rails/pull/73) already trying to solve the issue but seems like failing for CI. 

Hope this PR can silence deprecation while satisfying different versions of Sprockets, adopting the tips shared by @schneems in [this comment](https://github.com/sass/sassc-rails/pull/73#issuecomment-236214754). 

## CI Build

The [CI build failed](https://travis-ci.org/sass/sassc-rails/builds/148837899) but seems like master is already [broken](https://travis-ci.org/sass/sassc-rails/builds/148040463)(?), and these 2 look like identical, at least this sprockets 2 were passed which failed on #73. 

<img width="770" alt="build__139_-_sass_sassc-rails_-_travis_ci" src="https://cloud.githubusercontent.com/assets/184520/17291666/476fc4ec-5820-11e6-9eb1-23964e99c4df.png">



Related issue: https://github.com/sass/sassc-rails/issues/75