### PR TITLE
Stringify paths to unique paths correctly

### DIFF
--- a/lib/sassc/rails/importer.rb
+++ b/lib/sassc/rails/importer.rb
@@ -94,7 +94,9 @@ module SassC
           return glob_imports(base, m[2], parent_path)
         end
 
-        search_paths = ([parent_dir] + load_paths).uniq
+        # Compass and other gems us their own special loaders
+        # Hence making this to_s required to have a proper uniq set.
+        search_paths = ([parent_dir] + load_paths).map(&:to_s).uniq
 
         if specified_dir != "."
           search_paths.map! do |path|


### PR DESCRIPTION
The problem here is that gems like compass-sass and bootstrap-sass will
build their own Importer classes that aren't being properly uniqued.

This will resolve #79 