### PR TITLE
Allow Sass number precision to be configurable

### DIFF
--- a/lib/sassc/rails/template.rb
+++ b/lib/sassc/rails/template.rb
@@ -21,6 +21,7 @@ module SassC::Rails
           syntax: self.class.syntax,
           load_paths: input[:environment].paths,
           importer: SassC::Rails::Importer,
+          precision: ::Sass::Script::Value::Number.precision,
           sprockets: {
             context: context,
             environment: input[:environment],
@@ -52,6 +53,7 @@ module SassC::Rails
           syntax: syntax,
           load_paths: context.environment.paths,
           importer: SassC::Rails::Importer,
+          precision: ::Sass::Script::Value::Number.precision,
           sprockets: {
             context: context,
             environment: context.environment


### PR DESCRIPTION
Sass defaults to 5 digits of precision when performing calculations. This clashes with popular css frameworks like Bootstrap and Foundation. There is ongoing, unresolved discussion as to what defaults to uphold https://github.com/sass/sass/issues/1122.

In the meantime, libsass has made this configurable, but defaults to Sass' values, i.e. https://github.com/sass/libsass/issues/287 and https://github.com/sass/libsass/issues/675

Common workarounds involve editing the precision value directly, i.e. https://github.com/twbs/bootstrap-sass/blame/master/README.md#L78 using the provided accessor http://sass-lang.com/documentation/Sass/Script/Value/Number.html#precision%3D-class_method

This commit simply makes sassc-rails pass along that default value from Sass proper.

---

I wasn't quite sure if this is the right place to put it, but it solved the problems we were having. We use  (our own sassc fork of) twbs/bootstrap-sass, which sets the precision attribute.

Let me know what you think,