### PR TITLE
Use `File.exist?` instead of `File.exists?`

### DIFF
--- a/lib/sassc/rails/importer.rb
+++ b/lib/sassc/rails/importer.rb
@@ -108,7 +108,7 @@ module SassC
 
             EXTENSIONS.each do |extension|
               try_path = File.join(search_path, file_name + extension.postfix)
-              if File.exists?(try_path)
+              if File.exist?(try_path)
                 record_import_as_dependency try_path
                 return extension.import_for(try_path, parent_dir, options)
               end

--- a/test/sassc_rails_test.rb
+++ b/test/sassc_rails_test.rb
@@ -248,9 +248,9 @@ class SassRailsTest < MiniTest::Unit::TestCase
   #    css_output = asset_output('css_application.css')
   #    assert_match /globbed/, css_output
 
-  #    if File.exists?("#{app_root}/log/development.log")
+  #    if File.exist?("#{app_root}/log/development.log")
   #      log_file = "#{app_root}/log/development.log"
-  #    elsif File.exists?("#{app_root}/log/test.log")
+  #    elsif File.exist?("#{app_root}/log/test.log")
   #      log_file = "#{app_root}/log/test.log"
   #    else
   #      flunk "log file was not created"


### PR DESCRIPTION
The latter is deprecated.
Ref: https://ruby-doc.org/core-2.4.0/File.html#method-c-exists-3F

And the former is exist since at least Ruby 2.2 (it is the oldest version that supported by [sassc-rails](https://github.com/sass/sassc-rails/blob/v1.3.0/.travis.yml#L17)).
Ref: https://ruby-doc.org/core-2.2.0/File.html#method-c-exist-3F