### PR TITLE
Convert all files to frozen_string_literal: true

### DIFF
--- a/lib/sassc-rails.rb
+++ b/lib/sassc-rails.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "sass-rails"
   Rails::Railtie.subclasses.delete Sass::Rails::Railtie

--- a/lib/sassc/rails.rb
+++ b/lib/sassc/rails.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "rails/version"
 
 require "sassc"

--- a/lib/sassc/rails/compressor.rb
+++ b/lib/sassc/rails/compressor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'sprockets/sass_compressor'
 
 class Sprockets::SassCompressor

--- a/lib/sassc/rails/functions.rb
+++ b/lib/sassc/rails/functions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'sprockets/sass_functions'
 
 module Sprockets

--- a/lib/sassc/rails/importer.rb
+++ b/lib/sassc/rails/importer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tilt'
 
 module SassC

--- a/lib/sassc/rails/railtie.rb
+++ b/lib/sassc/rails/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/core_ext/class/attribute'
 require 'sprockets/railtie'
 

--- a/lib/sassc/rails/template.rb
+++ b/lib/sassc/rails/template.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "sprockets/version"
 
 begin

--- a/lib/sassc/rails/version.rb
+++ b/lib/sassc/rails/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SassC
   module Rails
     VERSION = "1.3.0"

--- a/test/sassc_rails_test.rb
+++ b/test/sassc_rails_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class SassRailsTest < MiniTest::Unit::TestCase

--- a/test/sassc_rails_test.rb
+++ b/test/sassc_rails_test.rb
@@ -167,7 +167,7 @@ class SassRailsTest < MiniTest::Unit::TestCase
 
     css_output = render_asset("css_scss_handler.css")
     assert_match %r{/* line 1}, css_output
-    assert_match %r{.+/sassc-rails/test/dummy/app/assets/stylesheets/css_scss_handler.css.scss}, css_output
+    assert_match %r{.+test/dummy/app/assets/stylesheets/css_scss_handler.css.scss}, css_output
   end
 
   def test_context_is_being_passed_to_erb_render
@@ -191,7 +191,7 @@ class SassRailsTest < MiniTest::Unit::TestCase
   def test_css_compressor_config_item_may_be_nil_in_test_mode
     @app.config.assets.css_compressor = nil
     initialize!
-    assert_equal nil, Rails.application.config.assets.css_compressor
+    assert_nil Rails.application.config.assets.css_compressor
   end
 
   def test_css_compressor_is_defined_in_test_mode

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV["RAILS_ENV"] = "test"
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))


### PR DESCRIPTION
This should help to reduce string allocations.