### PR TITLE
Avoid searching for files in nonexistant dirs

### DIFF
--- a/lib/sassc/rails/importer.rb
+++ b/lib/sassc/rails/importer.rb
@@ -100,6 +100,9 @@ module SassC
           search_paths.map! do |path|
             File.join(path, specified_dir)
           end
+          search_paths.select! do |path|
+            File.directory?(path)
+          end
         end
 
         search_paths.each do |search_path|

--- a/test/sassc_rails_test.rb
+++ b/test/sassc_rails_test.rb
@@ -167,7 +167,7 @@ class SassRailsTest < MiniTest::Unit::TestCase
 
     css_output = render_asset("css_scss_handler.css")
     assert_match %r{/* line 1}, css_output
-    assert_match %r{.+/sassc-rails/test/dummy/app/assets/stylesheets/css_scss_handler.css.scss}, css_output
+    assert_match %r{.+test/dummy/app/assets/stylesheets/css_scss_handler.css.scss}, css_output
   end
 
   def test_context_is_being_passed_to_erb_render
@@ -191,7 +191,7 @@ class SassRailsTest < MiniTest::Unit::TestCase
   def test_css_compressor_config_item_may_be_nil_in_test_mode
     @app.config.assets.css_compressor = nil
     initialize!
-    assert_equal nil, Rails.application.config.assets.css_compressor
+    assert_nil Rails.application.config.assets.css_compressor
   end
 
   def test_css_compressor_is_defined_in_test_mode


### PR DESCRIPTION
Search paths are determined by appending the specified dir to each directory in the `load_paths`. Though each dir in `load_paths` should exist, when a dir is specified, most `load_paths` dirs probably don't include it.

For each dir we skip in this way (requiring one stat through `File.directory?`) we save 16 `stat` calls (2 possible prefixes, and 8 possible extensions) looking for files.