### PR TITLE
Fix the ordering so that more specialised files are correctly picked

### DIFF
--- a/lib/sassc/rails/importer.rb
+++ b/lib/sassc/rails/importer.rb
@@ -75,13 +75,13 @@ module SassC
       EXTENSIONS = [
         CssScssExtension.new,
         CssSassExtension.new,
-        Extension.new(".scss"),
-        Extension.new(".sass"),
-        CSSExtension.new,
+        SassERBExtension.new,
         ERBExtension.new(".scss.erb"),
         ERBExtension.new(".css.erb"),
-        SassERBExtension.new
-      ]
+        Extension.new(".scss"),
+        Extension.new(".sass"),
+        CSSExtension.new
+      ].freeze
 
       PREFIXS = [ "", "_" ]
       GLOB = /(\A|\/)(\*|\*\*\/\*)\z/


### PR DESCRIPTION
When importing globs(`*`s) the current ordering of `EXTENSIONS` is not correct. 

For example if there is a `.scss.erb` file when a `glob` is expanded, it _should_ be imported by `ERBExtension.new(".scss.erb")` but the current ordering of `EXTENSIONS` picks `Extension.new(".scss")` which would then fail to parse the `.erb`.

I have re-ordered `EXTENSIONS` so that more specialised extensions appear first. 