### PR TITLE
Integrate Rails scss scaffolding from sass-rails.

### DIFF
--- a/lib/rails/generators/sass/assets/assets_generator.rb
+++ b/lib/rails/generators/sass/assets/assets_generator.rb
@@ -1,0 +1,13 @@
+require "rails/generators/named_base"
+
+module Sass
+  module Generators
+    class AssetsGenerator < ::Rails::Generators::NamedBase
+      source_root File.expand_path("../templates", __FILE__)
+
+      def copy_sass
+        template "stylesheet.sass", File.join('app/assets/stylesheets', class_path, "#{file_name}.sass")
+      end
+    end
+  end
+end

--- a/lib/rails/generators/sass/assets/templates/stylesheet.sass
+++ b/lib/rails/generators/sass/assets/templates/stylesheet.sass
@@ -1,0 +1,3 @@
+// Place all the styles related to the <%= name %> controller here.
+// They will automatically be included in application.css.
+// You can use Sass here: http://sass-lang.com/

--- a/lib/rails/generators/sass/scaffold/scaffold_generator.rb
+++ b/lib/rails/generators/sass/scaffold/scaffold_generator.rb
@@ -1,0 +1,9 @@
+require "rails/generators/sass_scaffold"
+
+module Sass
+  module Generators
+    class ScaffoldGenerator < ::Sass::Generators::ScaffoldBase
+      def syntax() :sass end
+    end
+  end
+end

--- a/lib/rails/generators/sass_scaffold.rb
+++ b/lib/rails/generators/sass_scaffold.rb
@@ -1,0 +1,15 @@
+require "sass/css"
+require "rails/generators/named_base"
+
+module Sass
+  module Generators
+    class ScaffoldBase < ::Rails::Generators::NamedBase
+      def copy_stylesheet
+        dir = ::Rails::Generators::ScaffoldGenerator.source_root
+        file = File.join(dir, "scaffold.css")
+        converted_contents = ::Sass::CSS.new(File.read(file)).render(syntax)
+        create_file "app/assets/stylesheets/scaffolds.#{syntax}", converted_contents
+      end
+    end
+  end
+end

--- a/lib/rails/generators/scss/assets/assets_generator.rb
+++ b/lib/rails/generators/scss/assets/assets_generator.rb
@@ -1,0 +1,13 @@
+require "rails/generators/named_base"
+
+module Scss
+  module Generators
+    class AssetsGenerator < ::Rails::Generators::NamedBase
+      source_root File.expand_path("../templates", __FILE__)
+
+      def copy_scss
+        template "stylesheet.scss", File.join('app/assets/stylesheets', class_path, "#{file_name}.scss")
+      end
+    end
+  end
+end

--- a/lib/rails/generators/scss/assets/templates/stylesheet.scss
+++ b/lib/rails/generators/scss/assets/templates/stylesheet.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the <%= name %> controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/lib/rails/generators/scss/scaffold/scaffold_generator.rb
+++ b/lib/rails/generators/scss/scaffold/scaffold_generator.rb
@@ -1,0 +1,10 @@
+require "rails/generators/sass_scaffold"
+
+module Scss
+  module Generators
+    class ScaffoldGenerator < ::Sass::Generators::ScaffoldBase
+      def syntax() :scss end
+    end
+  end
+end
+


### PR DESCRIPTION
This fixes #74 and is very similar (identical?) to the PR #86 which for some reason had it's fork deleted (probably why it wasn't merged?).

This commit simply adds the Rails scss scaffolding required to make the Rails generators work again with sassc-rails. It comes directly from the `lib/rails` directory of the sass-rails repo.

I was also experiencing the `error scss [not found]` issue, which now works as expected when I tested with `rails g scaffold` on this PR.