### PR TITLE
Update Rails 5.2 gemfile to use 5.2.3

### DIFF
--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "rails", "~> 5.2.1"
+gem "rails", "~> 5.2.3"
 
 # Specify your gem's dependencies in sassc-rails.gemspec
 gemspec path: "../"


### PR DESCRIPTION
In order to keep the CI running with latest versions in the tested gemfiles, this PR updates the Rails 5.2 version to the latest patch version of Rails.