### PR TITLE
Correct reference to SassC::Script::Value::String

### DIFF
--- a/lib/sassc/rails/functions.rb
+++ b/lib/sassc/rails/functions.rb
@@ -5,7 +5,7 @@ require 'sprockets/sass_functions'
 module Sprockets
   module SassFunctions
     def asset_data_url(path)
-      SassC::Script::String.new("url(" + sprockets_context.asset_data_uri(path.value) + ")")
+      ::SassC::Script::Value::String.new("url(" + sprockets_context.asset_data_uri(path.value) + ")")
     end
   end
 end


### PR DESCRIPTION
This part of the code was still referencing an older Sass Ruby constant path
Fixes #128