### PR TITLE
Update Travis with Rails 6 and to use all current minor releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ gemfile:
   - gemfiles/sprockets_4_0.gemfile
   - gemfiles/rails_4_2.gemfile
   - gemfiles/rails_5_2.gemfile
+  - gemfiles/rails_6_0.gemfile
 
 rvm:
   - 2.4.6
@@ -26,6 +27,11 @@ matrix:
   allow_failures:
     - gemfile: gemfiles/rails_4_2.gemfile
       rvm: jruby
+    - gemfile: gemfiles/rails_6_0.gemfile
+      rvm: jruby
+  exclude:
+    - gemfile: gemfiles/rails_6_0.gemfile
+      rvm: 2.4.6
 
 notifications:
   email: false

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem "rails", "~> 6.0.a"
+
+# Specify your gem's dependencies in sassc-rails.gemspec
+gemspec path: "../"

--- a/gemfiles/sprockets-rails_3_0.gemfile
+++ b/gemfiles/sprockets-rails_3_0.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "sprockets-rails", "~> 3.0.0"
+gem "sprockets-rails", "~> 3.2"
 
 # Specify your gem's dependencies in sassc-rails.gemspec
 gemspec path: "../"

--- a/gemfiles/sprockets_3_0.gemfile
+++ b/gemfiles/sprockets_3_0.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "sprockets", "~> 3.0.3"
+gem "sprockets", "~> 3.7"
 
 # Specify your gem's dependencies in sassc-rails.gemspec
 gemspec path: "../"


### PR DESCRIPTION
This adds a gemfile for running a CI build for Rails 6 (RC1). I thought it would help to get a head start on running CI builds for it to ensure compatibility.

This also addresses issues with the sprockets and sprockets-rails gemfiles where they were many minor versions behind the current version. As an example sprockets was only testing against 3.0.x but the latest minor version is 3.7.x.

I've noticed the jruby builds are only using 9.1.x but the latest is 9.2.x. Would you like an update to run against only 9.2.x?