### PR TITLE
Preprocess rails assets imported with extensions.

### DIFF
--- a/lib/sassc/rails/importer.rb
+++ b/lib/sassc/rails/importer.rb
@@ -112,7 +112,12 @@ module SassC
             file_name = prefix + specified_file
 
             EXTENSIONS.each do |extension|
-              try_path = File.join(search_path, file_name + extension.postfix)
+              try_file_name = if file_name.ends_with?(extension.postfix)
+                                file_name
+                              else
+                                file_name + extension.postfix
+                              end
+              try_path = File.join(search_path, try_file_name)
               if File.exist?(try_path)
                 record_import_as_dependency try_path
                 return extension.import_for(try_path, parent_dir, options)

--- a/test/dummy/app/assets/stylesheets/imports_with_extensions_test.scss
+++ b/test/dummy/app/assets/stylesheets/imports_with_extensions_test.scss
@@ -1,0 +1,8 @@
+@import "css_scss_handler.css.scss";
+@import "css_sass_handler.css.sass";
+@import "sass_erb_handler.sass.erb";
+@import "scss_erb_handler.scss.erb";
+@import "css_erb_handler.css.erb";
+@import "partials/scss_import.scss";
+@import "partials/sass_import.sass";
+@import "subfolder/plain.css";

--- a/test/sassc_rails_test.rb
+++ b/test/sassc_rails_test.rb
@@ -152,6 +152,20 @@ class SassRailsTest < MiniTest::Test
     assert_match /partial_in_load_paths/,    css_output
   end
 
+  def test_sass_imports_with_extensions
+    initialize!
+
+    css_output = render_asset("imports_with_extensions_test.css")
+    assert_match /css-scss-handler/,         css_output
+    assert_match /css-sass-handler/,         css_output
+    assert_match /sass-erb-handler/,         css_output
+    assert_match /scss-erb-handler/,         css_output
+    assert_match /css-erb-handler/,          css_output
+    assert_match /partial-scss/,             css_output
+    assert_match /partial-sass/,             css_output
+    assert_match /plain-old-css/,            css_output
+  end
+
   def test_style_config_item_is_defaulted_to_expanded_in_development_mode
     initialize_dev!
     assert_equal :expanded, Rails.application.config.sass.style


### PR DESCRIPTION
If a processed file imported an erb asset with the erb extension in the import
argument, these files would not be preprocessed by the sassc-rails and the
native sassc functions would fail to compile the assets.

This change checks if the import argument ends with any of the extensions known
by the sassc preprocessor, and if it does, applies the appropriate
preprocessing to that file.

Addresses #123 second issue