### PR TITLE
Fix segfault by defining the asset_url function in the right context

### DIFF
--- a/lib/sassc/rails/functions.rb
+++ b/lib/sassc/rails/functions.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
-require 'sprockets/sass_functions'
+begin
+  require 'sprockets/sassc_processor'
+  mod = Sprockets::SasscProcessor::Functions
+rescue LoadError
+  require 'sprockets/sass_functions'
+  mod = Sprockets::SassFunctions
+end
 
-module Sprockets
-  module SassFunctions
-    def asset_data_url(path)
-      ::SassC::Script::Value::String.new("url(" + sprockets_context.asset_data_uri(path.value) + ")")
-    end
+mod.instance_eval do
+  def asset_data_url(path)
+    ::SassC::Script::Value::String.new("url(" + sprockets_context.asset_data_uri(path.value) + ")")
   end
 end
 
-::SassC::Script::Functions.send :include, Sprockets::SassFunctions
+::SassC::Script::Functions.send :include, mod


### PR DESCRIPTION
Hello! I hit a segfault upon upgrading my app to to Sprockets 4.0, and eventually tracked it down to this.

I also think it might be the same issue as this: https://github.com/rails/sprockets/issues/633#issuecomment-561010553