### PR TITLE
try app_middleware instead of middleware

### DIFF
--- a/lib/sassc/rails/railtie.rb
+++ b/lib/sassc/rails/railtie.rb
@@ -28,7 +28,7 @@ module SassC::Rails
 
     # Remove the sass middleware if it gets inadvertently enabled by applications.
     config.after_initialize do |app|
-      app.config.middleware.delete(Sass::Plugin::Rack) if defined?(Sass::Plugin::Rack)
+      app.config.app_middleware.delete(Sass::Plugin::Rack) if defined?(Sass::Plugin::Rack)
     end
 
     initializer :setup_sass, group: :all do |app|


### PR DESCRIPTION
This is a re-application of the change originally attempted in https://github.com/rails/sass-rails/pull/386

It fixes https://github.com/rails/sass-rails/issues/136 and https://github.com/rails/sass-rails/issues/385, allowing this plugin to be used in a wider variety of contexts.

As with the original attempt, we're still not sure if this is the ideal fix and are open to suggestions of other ways to enable this functionality!
