### PR TITLE
Add source map on debug mode with Sprockets 4

### DIFF
--- a/lib/sassc/rails/template.rb
+++ b/lib/sassc/rails/template.rb
@@ -34,13 +34,36 @@ module SassC::Rails
         }
       }.merge!(config_options) { |key, left, right| safe_merge(key, left, right) }
 
+      if Rails.application.config.assets.debug && Sprockets::VERSION.start_with?("4")
+        options.merge!(
+          source_map_contents: false,
+          source_map_file: "#{input[:filename]}.map",
+          omit_source_map_url: true,
+        )
+      end
+
       engine = ::SassC::Engine.new(input[:data], options)
 
       css = Sprockets::Utils.module_include(::SassC::Script::Functions, @functions) do
         engine.render
       end
 
-      context.metadata.merge(data: css)
+      if Rails.application.config.assets.debug && Sprockets::VERSION.start_with?("4")
+        begin
+          map = Sprockets::SourceMapUtils.format_source_map(JSON.parse(engine.source_map), input)
+          map = Sprockets::SourceMapUtils.combine_source_maps(input[:metadata][:map], map)
+
+          engine.dependencies.each do |dependency|
+            context.metadata[:dependencies] << Sprockets::URIUtils.build_file_digest_uri(dependency.filename)
+          end
+        rescue SassC::NotRenderedError
+          map = input[:metadata][:map]
+        end
+
+        context.metadata.merge(data: css, map: map)
+      else
+        context.metadata.merge(data: css)
+      end
     end
 
     def config_options

--- a/test/sassc_rails_test.rb
+++ b/test/sassc_rails_test.rb
@@ -246,7 +246,7 @@ class SassRailsTest < MiniTest::Test
   end
 
   def test_adds_source_map_in_debug_mode
-    if Sprockets::VERSION.start_with?("4")
+    unless Sprockets::VERSION.start_with?("3")
       @app.config.assets.debug = true
       initialize_dev!
 

--- a/test/sassc_rails_test.rb
+++ b/test/sassc_rails_test.rb
@@ -225,6 +225,7 @@ class SassRailsTest < MiniTest::Test
   end
 
   def test_sassc_compression_is_used
+    @app.config.assets.debug = false
     engine = stub(render: "")
     SassC::Engine.expects(:new).returns(engine)
     SassC::Engine.expects(:new).with("", {style: :compressed}).returns(engine)
@@ -235,12 +236,25 @@ class SassRailsTest < MiniTest::Test
   end
 
   def test_allows_for_inclusion_of_inline_source_maps
+    @app.config.assets.debug = false
     @app.config.sass.inline_source_maps = true
     initialize_dev!
 
     asset = render_asset("application.css")
     assert_match /.hello/, asset
     assert_match /sourceMappingURL/, asset
+  end
+
+  def test_adds_source_map_in_debug_mode
+    if Sprockets::VERSION.start_with?("4")
+      @app.config.assets.debug = true
+      initialize_dev!
+
+      asset = render_asset("glob_test.debug.css")
+      assert_equal app.assets["glob_test.css"].metadata[:map]["sections"].first["map"]["sources"], ["glob_test.source.scss", "globbed/globbed.source.scss", "globbed/nested/nested_glob.source.scss"]
+      assert_match /.globbed/, asset
+      assert_match /sourceMappingURL/, asset
+    end
   end
 
   #test 'sprockets require works correctly' do


### PR DESCRIPTION
This fix https://github.com/sass/sassc-rails/issues/161. With Sprockets 4, when debug mode was enabled, the source map wasn't added correctly at the end of the file.