### PR TITLE
gemspec: Drop unused directives

### DIFF
--- a/sassc-rails.gemspec
+++ b/sassc-rails.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
This gem exposes no executables, and test_files is not used by RubyGems.org.