### PR TITLE
CI: Configure GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: build ${{ matrix.ruby }}
+    env:
+      BUNDLE_GEMFILE: "gemfiles/${{ matrix.gemfile-base }}.gemfile"
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - 2.6
+          - 2.7
+          - '3.0'
+          - 3.1
+          - truffleruby-head
+        gemfile-base:
+          - sprockets-rails_3_0
+          - sprockets-rails_2_3
+          - sprockets_3_0
+          - sprockets_4_0
+          - rails_4_2
+          - rails_5_2
+          - rails_6_0
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true # 'bundle install' and cache gems
+
+      - name: Test
+        continue-on-error: ${{ matrix.experimental }}
+        run: bundle exec rake


### PR DESCRIPTION
This PR adds a GitHub Actions CI configuration. 🎉 

This uses Ruby 2.6-and-up in its build matrix, and reuses the existing gemfiles.

Needs:

- Enable Actions to run ⚙️ 
- ~Add `exclude` for combinations that can not run~ (There were no combination that needed an exclude, what I can see.)

Fixes #168.