### PR TITLE
Fix compatibility chart link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ application.css file.
 ## LibSass Compatibility With Ruby Sass
 
 For a look at the compatibility between Ruby Sass and LibSass, check this
-[compatibility chart](http://sass-compatibility.github.io/) out.
+[compatibility chart](https://web.archive.org/web/20201008171201/http://sass-compatibility.github.io/) out.
 
 
 ## Installation


### PR DESCRIPTION
http://sass-compatibility.github.io seems to have be gone for over a year now. Replaced with an archive.org link to the most recent version.