### PR TITLE
Fix compatibility with Minitest 5.19+

### DIFF
--- a/test/sassc_rails_test.rb
+++ b/test/sassc_rails_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class SassRailsTest < MiniTest::Test
+class SassRailsTest < Minitest::Test
   attr_reader :app
 
   def setup


### PR DESCRIPTION
The `MiniTest` was renamed to `Minitest`:

https://github.com/minitest/minitest/commit/9a57c520ceac76abfe6105866f8548a94eb357b6

And the `MiniTest` constant is now loaded just when `MT_COMPAT` environment variable is set:

https://github.com/minitest/minitest/commit/a2c6c18570f6f0a1bf6af70fe3b6d9599a13fdd6

This fixes errors such as:

~~~
$ ruby -Ilib:test -rsass-rails -rsprockets/railtie -e 'Dir.glob "./test/**/*.rb", &method(:require)' /builddir/build/BUILD/sassc-rails-2.1.2/usr/share/gems/gems/sassc-rails-2.1.2/test/sassc_rails_test.rb:6:in `<top (required)>': uninitialized constant MiniTest (NameError) class SassRailsTest < MiniTest::Test
                              ^^^^^^
Did you mean?  Minitest
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:dir>:220:in `glob'
	from -e:1:in `<main>'
~~~